### PR TITLE
修复DeepSeek.java中ID排除功能异常的问题

### DIFF
--- a/plugins/CK/DeepSeek/DeepSeek.java
+++ b/plugins/CK/DeepSeek/DeepSeek.java
@@ -223,8 +223,13 @@ void onHandleMsg(Object msgInfoBean) {
             if (hasForbiddenWord(userContent)) {
                 return;
             }
-
-            // 第二步：关键词触发逻辑
+            // 第二步：ID排除判断
+            for (String excluded : excludedIds) {
+                if (excluded.equals(talkerId)) {
+                    return; // 跳过处理
+                }
+            }
+            // 第三步：关键词触发逻辑
             boolean containsTrigger = false;
             if (privateTriggerWords.length == 0) {
                 containsTrigger = true;


### PR DESCRIPTION
代码中定义了 excludedIds 数组：

String[] excludedIds = {}; // 填写需要排除的用户ID

但在 onHandleMsg() 主入口里没有使用 excludedIds 进行排除判断。